### PR TITLE
Migrate from buf check lint to buf lint

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-2020 The Buf Authors
+   Copyright 2020-2021 Buf Technologies, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Using [vim-plug](https://github.com/junegunn/vim-plug), add the following to you
 Plug 'dense-analysis/ale'
 Plug 'bufbuild/vim-buf'
 let g:ale_linters = {
-\   'proto': ['buf-check-lint',],
+\   'proto': ['buf-lint',],
 \}
 let g:ale_lint_on_text_changed = 'never'
 let g:ale_linters_explicit = 1
 ```
 
-This will result in individual files being linted on save via `buf check lint --path`. Note that
-some lint checkers are dependent on checking multiple files at once, for example the lint checkers
+This will result in individual files being linted on save via `buf lint --path`. Note that
+some lint rules are dependent on checking multiple files at once, for example the lint rules
 in the `PACKAGE_AFFINITY` category, so we still recommend your CI setup runs `buf check lint`.
 
 Buf will be executed in your current directory, which results in your configuration being read

--- a/ale_linters/proto/buf_lint.vim
+++ b/ale_linters/proto/buf_lint.vim
@@ -1,9 +1,7 @@
-" Description: Run buf check lint.
-"
-" This is deprecated. Switch to the buf-lint linter instead.
+" Description: Run buf lint.
 
 call ale#linter#Define('proto', {
-\   'name': 'buf-check-lint',
+\   'name': 'buf-lint',
 \   'lint_file': 1,
 \   'output_stream': 'stdout',
 \   'executable': 'buf',


### PR DESCRIPTION
The existing `buf-check-lint` linter remains for backwards compatibility.

https://github.com/bufbuild/buf/pull/229