### PR TITLE
TCN-665 add release tag workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: The version you intend to release (eg x.y.z)
+
+env:
+  VERSION: ${{ github.event.inputs.version }}
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version != '' }}
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: 251311
+          private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
+          repository: ${{ github.repository }}
+          permissions: >-
+            {"contents": "write"}
+      - name: Checkout repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          fetch-depth: 0
+      - name: Tag Release
+        run: |
+          git config --global user.password ${{ steps.generate_token.outputs.token }}
+          git tag -a v${{env.VERSION}} 2> /dev/null || echo 'local ref does not exist'
+          git push origin :v${{env.VERSION}} 2> /dev/null || echo 'remote ref does not exist'
+          git tag -a "v${{env.VERSION}}" -m "v${{env.VERSION}}"
+          git push origin v${{env.VERSION}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: 251311
+          app_id: 257261
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repository: ${{ github.repository }}
           permissions: >-


### PR DESCRIPTION
adds workflow for release flow:
```sh
cd "${BUFBUILD_VIM_BUF_DIR}"
git switch main
git pull origin main
git diff

git tag -a "v${VERSION}" -m "v${VERSION}"
git push origin "v${VERSION}"
```